### PR TITLE
ci: Fix double triggering of release workflows

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,12 +1,11 @@
 name: Docker Release
 
+# Only trigger on GitHub release publication, not on tag push.
+# When a release is created, GitHub fires both 'release' and 'push' events.
+# Using only 'release' prevents duplicate workflow runs.
 on:
   release:
     types: [published]
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 # Cancel in-progress runs for the same tag
 concurrency:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,8 @@
 name: Docker Build
 
+# Build and test Docker images on pushes to main and pull requests.
+# Note: Version tags (v*) are NOT included here - they trigger docker-release.yaml
+# via the 'release: published' event instead, to avoid duplicate workflow runs.
 on:
   push:
     branches: [main, master]
@@ -9,8 +12,6 @@ on:
       - "src/**/*.py"
       - "pyproject.toml"
       - ".github/workflows/docker.yaml"
-    tags:
-      - "v*"
   pull_request:
     branches: [main, master]
     paths:

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,12 +1,11 @@
 name: PyPI Release
 
+# Only trigger on GitHub release publication, not on tag push.
+# When a release is created, GitHub fires both 'release' and 'push' events.
+# Using only 'release' prevents duplicate workflow runs.
 on:
   release:
     types: [published]
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 # Cancel in-progress runs for the same tag
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD release workflows to trigger only on published release events rather than duplicate tag push patterns. Workflows for container and package manager distributions now consolidate on a single trigger mechanism, eliminating redundant builds and improving release process efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->