### PR TITLE
fix: Resolves crash when GC cleans QTimer objects

### DIFF
--- a/.github/workflows/test-gui.yaml
+++ b/.github/workflows/test-gui.yaml
@@ -160,9 +160,10 @@ jobs:
 
               echo "FreeCAD GUI mode confirmed!"
 
-              # Run GUI integration tests
+              # Run GUI integration tests (excluding standalone tests)
               echo "Running GUI integration tests..."
               uv run pytest tests/integration/test_gui_mode.py -v --tb=short -x \
+                -m "not standalone_freecad" \
                 --junit-xml=/test-output/gui-test-results.xml \
                 || TEST_EXIT=$?
 
@@ -170,9 +171,22 @@ jobs:
               cp /tmp/*.png /test-output/ 2>/dev/null || true
               cp /tmp/*.FCStd /test-output/ 2>/dev/null || true
 
-              # Cleanup
+              # Cleanup - stop the FreeCAD process that was running for GUI tests
+              echo "Stopping FreeCAD for GUI tests..."
               kill $XDOT_PID 2>/dev/null || true
               kill $FREECAD_PID 2>/dev/null || true
+              sleep 2  # Give it time to shut down
+
+              # Now run standalone tests (shutdown crash tests) - these manage their own FreeCAD
+              if [ "${TEST_EXIT:-0}" -eq 0 ]; then
+                echo ""
+                echo "Running standalone FreeCAD tests (shutdown crash detection)..."
+                uv run pytest tests/integration/test_shutdown_crash.py -v --tb=short \
+                  --junit-xml=/test-output/shutdown-test-results.xml \
+                  || TEST_EXIT=$?
+              else
+                echo "Skipping standalone tests due to earlier failures"
+              fi
 
               exit ${TEST_EXIT:-0}
             '

--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,7 @@ Thumbs.db
 *.FCStd
 *.FCStd1
 *.FCBak
-freecad-headless.log
+*.log
 
 # Local configuration
 .mcp.json

--- a/freecad/RobustMCPBridge/__init__.py
+++ b/freecad/RobustMCPBridge/__init__.py
@@ -129,9 +129,19 @@ def _auto_start_bridge() -> None:
 # will see GuiUp=False and use a background thread. Later, code executed on that
 # thread will try to do Qt operations, causing crashes (SIGABRT in QCocoaWindow).
 try:
+    import os
+
     from preferences import get_auto_start
 
-    _auto_start_enabled = get_auto_start()
+    # In testing mode, skip auto-start so the test controls bridge lifecycle
+    # via startup_bridge.py (same guard as in init_gui.py).
+    if os.environ.get("FREECAD_MCP_TESTING"):
+        _auto_start_enabled = False
+        FreeCAD.Console.PrintMessage(
+            "Robust MCP Bridge: Auto-start skipped (FREECAD_MCP_TESTING set)\n"
+        )
+    else:
+        _auto_start_enabled = get_auto_start()
     FreeCAD.Console.PrintMessage(
         f"Robust MCP Bridge: Auto-start preference = {_auto_start_enabled}\n"
     )

--- a/freecad/RobustMCPBridge/__init__.py
+++ b/freecad/RobustMCPBridge/__init__.py
@@ -136,17 +136,17 @@ try:
     # In testing mode, skip auto-start so the test controls bridge lifecycle
     # via startup_bridge.py (same guard as in init_gui.py).
     if os.environ.get("FREECAD_MCP_TESTING"):
-        _auto_start_enabled = False
+        _autoStartEnabled = False
         FreeCAD.Console.PrintMessage(
             "Robust MCP Bridge: Auto-start skipped (FREECAD_MCP_TESTING set)\n"
         )
     else:
-        _auto_start_enabled = get_auto_start()
+        _autoStartEnabled = get_auto_start()
     FreeCAD.Console.PrintMessage(
-        f"Robust MCP Bridge: Auto-start preference = {_auto_start_enabled}\n"
+        f"Robust MCP Bridge: Auto-start preference = {_autoStartEnabled}\n"
     )
 
-    if _auto_start_enabled:
+    if _autoStartEnabled:
         # Try to import Qt and check for running QApplication
         import contextlib
 

--- a/freecad/RobustMCPBridge/init_gui.py
+++ b/freecad/RobustMCPBridge/init_gui.py
@@ -271,10 +271,20 @@ try:
 
             FreeCAD.Console.PrintError(traceback.format_exc())
 
-    # Check if auto-start is enabled before scheduling
+    # Check if auto-start is enabled before scheduling.
+    # In testing mode (FREECAD_MCP_TESTING=1), skip auto-start so the test
+    # controls bridge lifecycle via startup_bridge.py.  Without this guard,
+    # the auto-start timer and startup_bridge.py race to start the bridge,
+    # which can cause port conflicts or duplicate initialisation.
+    import os
+
     from preferences import get_auto_start
 
-    if get_auto_start():
+    if os.environ.get("FREECAD_MCP_TESTING"):
+        FreeCAD.Console.PrintMessage(
+            "Robust MCP Bridge: Auto-start skipped (FREECAD_MCP_TESTING set)\n"
+        )
+    elif get_auto_start():
         # Schedule auto-start after a delay to ensure GUI is fully ready.
         # InitGui.py module-level code runs early in FreeCAD startup, so we
         # need to defer the bridge start to avoid race conditions.

--- a/just/testing.just
+++ b/just/testing.just
@@ -454,9 +454,9 @@ integration-headless-release:
     echo "FreeCAD Robust MCP Bridge is ready! (headless mode)"
     echo ""
 
-    # Run integration tests
+    # Run integration tests (excluding standalone tests that require GUI mode)
     TEST_EXIT_CODE=0
-    uv run pytest "{{project_root}}/tests/integration" -v || TEST_EXIT_CODE=$?
+    uv run pytest "{{project_root}}/tests/integration" -v -m "not standalone_freecad" || TEST_EXIT_CODE=$?
 
     # Cleanup handled by trap
     rm -f "$FREECAD_LOG" 2>/dev/null || true
@@ -544,11 +544,29 @@ integration-gui-release:
     echo "FreeCAD Robust MCP Bridge is ready! (GUI mode)"
     echo ""
 
-    # Run integration tests
+    # Run integration tests (excluding standalone tests that need their own FreeCAD)
     TEST_EXIT_CODE=0
-    uv run pytest "{{project_root}}/tests/integration" -v || TEST_EXIT_CODE=$?
+    echo "Running GUI integration tests..."
+    uv run pytest "{{project_root}}/tests/integration" -v -m "not standalone_freecad" || TEST_EXIT_CODE=$?
 
-    # Cleanup handled by trap
+    # Stop FreeCAD before running standalone tests
+    echo ""
+    echo "Stopping FreeCAD for standalone tests..."
+    cleanup
+    STARTED_FREECAD=false  # Prevent double cleanup
+    sleep 3  # Give FreeCAD time to fully exit
+
+    # Run standalone tests (shutdown crash detection) - these manage their own FreeCAD
+    if [ "$TEST_EXIT_CODE" -eq 0 ]; then
+        echo ""
+        echo "Running standalone FreeCAD tests (shutdown crash detection)..."
+        uv run pytest "{{project_root}}/tests/integration/test_shutdown_crash.py" -v || TEST_EXIT_CODE=$?
+    else
+        echo ""
+        echo "Skipping standalone tests due to earlier failures"
+    fi
+
+    # Cleanup handled by trap (but we already stopped FreeCAD)
     rm -f "$FREECAD_LOG" 2>/dev/null || true
     exit $TEST_EXIT_CODE
 

--- a/just/testing.just
+++ b/just/testing.just
@@ -554,7 +554,18 @@ integration-gui-release:
     echo "Stopping FreeCAD for standalone tests..."
     cleanup
     STARTED_FREECAD=false  # Prevent double cleanup
-    sleep 3  # Give FreeCAD time to fully exit
+
+    # Wait until ports are actually free before starting standalone tests.
+    # A fixed sleep is not enough — FreeCAD's GUI process can take 10+ seconds
+    # to fully exit on macOS, and a lingering bridge causes the standalone test
+    # to connect to the OLD instance instead of the NEW one it starts.
+    wait_for_ports_free 30
+
+    # Ports free doesn't mean the process exited — on macOS the GUI lingers
+    # while saving preferences and tearing down the 3D viewer.  Starting a
+    # second FreeCAD while the first is still alive causes:
+    #   "Tried to run Gui::Application::initApplication() twice!" → SIGSEGV
+    wait_for_freecad_exit 30
 
     # Run standalone tests (shutdown crash detection) - these manage their own FreeCAD
     if [ "$TEST_EXIT_CODE" -eq 0 ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,10 @@ ignore_missing_imports = true
 # Required for namespace packages (freecad/) to prevent "found twice" errors
 explicit_package_bases = true
 namespace_packages = true
+# Tell mypy that src/ is a source root, not a package directory.
+# Without this, `uv run mypy src/` creates "src.freecad_mcp._version" which
+# conflicts with the installed "freecad_mcp._version".
+mypy_path = "src"
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,9 @@ warn_unused_ignores = false
 warn_no_return = true
 follow_imports = "silent"
 ignore_missing_imports = true
+# Required for namespace packages (freecad/) to prevent "found twice" errors
+explicit_package_bases = true
+namespace_packages = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"
@@ -287,6 +290,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks integration tests requiring FreeCAD",
     "gui: marks tests requiring FreeCAD GUI mode (not headless)",
+    "standalone_freecad: marks tests that start/stop their own FreeCAD process (run separately)",
 ]
 
 [tool.coverage.run]

--- a/src/freecad_mcp/__init__.py
+++ b/src/freecad_mcp/__init__.py
@@ -20,13 +20,16 @@ Example:
 
 from importlib.metadata import PackageNotFoundError, version
 
+__version__: str
 try:
     __version__ = version("freecad-robust-mcp")
 except PackageNotFoundError:
     # Package is not installed (running from source without pip install -e)
     # Fall back to the generated _version.py if available
     try:
-        from freecad_mcp._version import __version__
+        from freecad_mcp._version import __version__ as _v
+
+        __version__ = _v
     except ImportError:
         __version__ = "0.0.0.dev0+unknown"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -219,8 +219,14 @@ def pytest_terminal_summary(
     This provides clear visibility into which mode was used and confirms
     successful connection.
     """
-    # Only show summary if we ran integration tests
+    # Only show summary if we ran integration tests that needed the bridge.
+    # _connection_checked is set when non-standalone tests required a bridge;
+    # _bridge_available is None when no check was performed at all.
+    # When only standalone_freecad tests ran, skip the summary to avoid a
+    # misleading "FAILED" message (standalone tests manage their own FreeCAD).
     if _bridge_available is None:
+        return
+    if not _connection_checked and not _bridge_available:
         return
 
     # Build the summary message
@@ -235,7 +241,7 @@ def pytest_terminal_summary(
     else:
         terminalreporter.write_line("  Connection: FAILED")
         if _bridge_error:
-            terminalreporter.write_line(f"  Error:      {_bridge_error}")
+            terminalreporter.write_line(f"  Warning:    {_bridge_error}")
 
     terminalreporter.write_line("")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -180,14 +180,14 @@ def pytest_collection_modifyitems(
 
     # Check if all tests are standalone (they start their own FreeCAD)
     # These tests don't need a pre-existing bridge connection
-    non_standalone_tests = [
+    nonStandaloneTests = [
         item
         for item in integration_tests
         if not any(mark.name == "standalone_freecad" for mark in item.iter_markers())
     ]
 
     # If all tests are standalone, skip the bridge check entirely
-    if not non_standalone_tests:
+    if not nonStandaloneTests:
         return
 
     # Check bridge connection once

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -164,6 +164,9 @@ def pytest_collection_modifyitems(
 
     This runs once during test collection. If the bridge is not available,
     this raises a hard error instead of skipping tests.
+
+    Exception: Tests marked with `standalone_freecad` start their own FreeCAD
+    process and don't require a pre-existing bridge connection.
     """
     global _connection_checked
 
@@ -173,6 +176,18 @@ def pytest_collection_modifyitems(
     ]
 
     if not integration_tests:
+        return
+
+    # Check if all tests are standalone (they start their own FreeCAD)
+    # These tests don't need a pre-existing bridge connection
+    non_standalone_tests = [
+        item
+        for item in integration_tests
+        if not any(mark.name == "standalone_freecad" for mark in item.iter_markers())
+    ]
+
+    # If all tests are standalone, skip the bridge check entirely
+    if not non_standalone_tests:
         return
 
     # Check bridge connection once

--- a/tests/integration/test_shutdown_crash.py
+++ b/tests/integration/test_shutdown_crash.py
@@ -1,0 +1,449 @@
+"""Tests for FreeCAD shutdown crash prevention.
+
+These tests verify that FreeCAD can shut down cleanly when the MCP bridge
+is running, without crashing due to Qt/PySide cleanup issues.
+
+The crash scenario:
+1. FreeCAD starts with MCP bridge (creates QTimer objects)
+2. User closes FreeCAD
+3. Python's atexit handlers run
+4. Python's Py_FinalizeEx() runs garbage collection
+5. GC tries to finalize PySide QTimer wrappers
+6. PySide destructor triggers Qt's disconnectNotify callback
+7. disconnectNotify calls back into partially-finalized Python
+8. CRASH (SIGSEGV in _PyType_Lookup)
+
+The fix uses shiboken.delete() in the atexit handler to explicitly destroy
+the Qt/C++ objects before Python's GC runs, preventing the crash.
+
+These tests are marked as slow because they start/stop FreeCAD processes.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Signal numbers for crash detection
+SIGSEGV = 11
+SIGABRT = 6
+
+# Exit codes that indicate a crash
+# On Unix, signal exits are typically -signal or 128+signal
+CRASH_EXIT_CODES = {
+    -SIGSEGV,  # Killed by SIGSEGV
+    -SIGABRT,  # Killed by SIGABRT
+    128 + SIGSEGV,  # 139 - shell convention for SIGSEGV
+    128 + SIGABRT,  # 134 - shell convention for SIGABRT
+}
+
+
+def _is_bridge_running(host: str = "localhost", port: int = 9875) -> bool:
+    """Check if an MCP bridge is already running on the given port.
+
+    Args:
+        host: Bridge hostname.
+        port: Bridge XML-RPC port.
+
+    Returns:
+        True if a bridge is responding, False otherwise.
+    """
+    import xmlrpc.client
+
+    try:
+        proxy = xmlrpc.client.ServerProxy(f"http://{host}:{port}", allow_none=True)
+        result = proxy.ping()
+        return isinstance(result, dict) and bool(result.get("pong"))
+    except Exception:
+        return False
+
+
+def _find_freecad_binary() -> str | None:
+    """Find the FreeCAD GUI binary path.
+
+    Returns:
+        Path to FreeCAD binary, or None if not found.
+    """
+    if platform.system() == "Darwin":
+        # macOS: Use the actual binary, not the .app bundle
+        paths = [
+            "/Applications/FreeCAD.app/Contents/Resources/bin/freecad",
+            os.path.expanduser(
+                "~/Applications/FreeCAD.app/Contents/Resources/bin/freecad"
+            ),
+        ]
+    elif platform.system() == "Linux":
+        paths = [
+            "/usr/bin/freecad",
+            "/usr/local/bin/freecad",
+            "/opt/freecad/bin/FreeCAD",
+        ]
+        # Also check PATH
+        import shutil
+
+        freecad_in_path = shutil.which("freecad") or shutil.which("FreeCAD")
+        if freecad_in_path:
+            paths.insert(0, freecad_in_path)
+    else:
+        # Windows
+        paths = [
+            os.path.join(
+                os.environ.get("PROGRAMFILES", ""), "FreeCAD 1.0/bin/FreeCAD.exe"
+            ),
+            os.path.join(os.environ.get("PROGRAMFILES", ""), "FreeCAD/bin/FreeCAD.exe"),
+        ]
+
+    for path in paths:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+
+    return None
+
+
+def _wait_for_bridge(
+    host: str = "localhost", port: int = 9875, timeout: float = 60.0
+) -> bool:
+    """Wait for the MCP bridge to become available.
+
+    Args:
+        host: Bridge hostname.
+        port: Bridge XML-RPC port.
+        timeout: Maximum time to wait in seconds.
+
+    Returns:
+        True if bridge is available, False if timeout.
+    """
+    import xmlrpc.client
+
+    start_time = time.time()
+    proxy = xmlrpc.client.ServerProxy(f"http://{host}:{port}", allow_none=True)
+
+    while time.time() - start_time < timeout:
+        try:
+            result = proxy.ping()
+            if isinstance(result, dict) and result.get("pong"):
+                return True
+        except Exception:
+            pass
+        time.sleep(0.5)
+
+    return False
+
+
+def _send_quit_command(host: str = "localhost", port: int = 9875) -> bool:
+    """Send quit command to FreeCAD via the MCP bridge.
+
+    Args:
+        host: Bridge hostname.
+        port: Bridge XML-RPC port.
+
+    Returns:
+        True if command was sent successfully.
+    """
+    import xmlrpc.client
+
+    try:
+        proxy = xmlrpc.client.ServerProxy(f"http://{host}:{port}", allow_none=True)
+        # Use FreeCADGui.getMainWindow().close() for a clean shutdown
+        # This triggers the normal Qt close event which will run atexit handlers
+        proxy.execute(
+            """
+import FreeCADGui
+if FreeCAD.GuiUp:
+    main_window = FreeCADGui.getMainWindow()
+    if main_window:
+        main_window.close()
+"""
+        )
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def freecad_binary() -> str:
+    """Get the FreeCAD binary path or skip if not found."""
+    binary = _find_freecad_binary()
+    if binary is None:
+        pytest.skip("FreeCAD binary not found")
+        raise AssertionError("Unreachable")  # For mypy - skip always raises
+    return binary
+
+
+@pytest.fixture
+def startup_script() -> str:
+    """Get the path to the bridge startup script."""
+    # Find the project root
+    tests_dir = Path(__file__).parent
+    project_root = tests_dir.parent.parent
+
+    script_path = (
+        project_root
+        / "freecad"
+        / "RobustMCPBridge"
+        / "freecad_mcp_bridge"
+        / "startup_bridge.py"
+    )
+
+    if not script_path.exists():
+        pytest.skip(f"Startup script not found: {script_path}")
+
+    return str(script_path)
+
+
+@pytest.mark.standalone_freecad
+@pytest.mark.timeout(120)  # 2 minute timeout for the entire test
+class TestShutdownCrash:
+    """Tests for FreeCAD shutdown without crashes.
+
+    These tests start their own FreeCAD process and must NOT run while another
+    FreeCAD instance with the MCP bridge is running (they would conflict on ports).
+
+    Run these tests separately:
+        uv run pytest tests/integration/test_shutdown_crash.py -v
+
+    Or exclude them from normal integration test runs:
+        uv run pytest tests/integration -v -m "not standalone_freecad"
+    """
+
+    @pytest.fixture(autouse=True)
+    def check_no_existing_bridge(self):
+        """Skip if a bridge is already running (would conflict on ports)."""
+        if _is_bridge_running():
+            pytest.skip(
+                "MCP bridge already running on port 9875. "
+                "These tests must run without an existing FreeCAD/bridge instance. "
+                "Stop FreeCAD and run: uv run pytest tests/integration/test_shutdown_crash.py -v"
+            )
+
+    def test_gui_shutdown_no_crash(
+        self,
+        freecad_binary: str,
+        startup_script: str,
+    ) -> None:
+        """Test that FreeCAD GUI shuts down cleanly with MCP bridge running.
+
+        This test:
+        1. Starts FreeCAD in GUI mode with the MCP bridge
+        2. Waits for the bridge to be ready
+        3. Sends a quit command via XML-RPC
+        4. Verifies FreeCAD exits with code 0 (not a crash)
+
+        A crash would result in exit code 139 (SIGSEGV) or 134 (SIGABRT).
+        """
+        # Start FreeCAD with the bridge startup script
+        env = os.environ.copy()
+        # Set testing mode so the bridge prints its instance ID
+        env["FREECAD_MCP_TESTING"] = "1"
+
+        # On macOS, we need to use the binary directly, not `open`
+        # This allows us to capture the exit code
+        # S603: Safe - freecad_binary is from _find_freecad_binary(), not user input
+        proc = subprocess.Popen(  # noqa: S603
+            [freecad_binary, startup_script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+
+        try:
+            # Wait for bridge to be ready
+            bridge_ready = _wait_for_bridge(timeout=60.0)
+            if not bridge_ready:
+                # Kill the process and fail
+                proc.terminate()
+                proc.wait(timeout=10)
+                pytest.fail("MCP bridge did not become available within timeout")
+
+            # Give FreeCAD a moment to fully stabilize
+            time.sleep(2)
+
+            # Send quit command
+            quit_sent = _send_quit_command()
+            if not quit_sent:
+                # Try to terminate gracefully
+                proc.terminate()
+
+            # Wait for FreeCAD to exit
+            try:
+                exit_code = proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                # Force kill if it doesn't exit
+                proc.kill()
+                exit_code = proc.wait(timeout=10)
+
+            # Check for crash exit codes
+            if exit_code in CRASH_EXIT_CODES:
+                # Get stderr for debugging
+                _, stderr = proc.communicate(timeout=5)
+                stderr_text = stderr.decode("utf-8", errors="replace") if stderr else ""
+
+                crash_signal = (
+                    "SIGSEGV" if exit_code in (-SIGSEGV, 128 + SIGSEGV) else "SIGABRT"
+                )
+                pytest.fail(
+                    f"FreeCAD crashed during shutdown with {crash_signal} "
+                    f"(exit code {exit_code}).\n"
+                    f"This indicates the QTimer cleanup fix may not be working.\n"
+                    f"stderr: {stderr_text[:1000]}"
+                )
+
+            # Exit code 0 or small positive values are acceptable
+            # Some GUI frameworks return 1 on close, which is not a crash
+            assert exit_code not in CRASH_EXIT_CODES, (
+                f"FreeCAD exited with crash-like code {exit_code}"
+            )
+
+        finally:
+            # Ensure process is cleaned up
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+
+    def test_sigterm_shutdown_no_crash(
+        self,
+        freecad_binary: str,
+        startup_script: str,
+    ) -> None:
+        """Test that FreeCAD handles SIGTERM gracefully with MCP bridge.
+
+        This tests the scenario where FreeCAD is terminated by a signal
+        (e.g., from a process manager or IDE).
+        """
+        if platform.system() == "Windows":
+            pytest.skip("SIGTERM test not applicable on Windows")
+
+        env = os.environ.copy()
+        env["FREECAD_MCP_TESTING"] = "1"
+
+        # S603: Safe - freecad_binary is from _find_freecad_binary(), not user input
+        proc = subprocess.Popen(  # noqa: S603
+            [freecad_binary, startup_script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+
+        try:
+            # Wait for bridge to be ready
+            bridge_ready = _wait_for_bridge(timeout=60.0)
+            if not bridge_ready:
+                proc.terminate()
+                proc.wait(timeout=10)
+                pytest.fail("MCP bridge did not become available within timeout")
+
+            # Give FreeCAD time to fully stabilize
+            time.sleep(2)
+
+            # Send SIGTERM (graceful termination)
+            proc.send_signal(signal.SIGTERM)
+
+            # Wait for exit
+            try:
+                exit_code = proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                exit_code = proc.wait(timeout=10)
+
+            # SIGTERM should result in clean exit or -SIGTERM
+            # It should NOT result in SIGSEGV or SIGABRT
+            if exit_code in (-SIGSEGV, 128 + SIGSEGV, -SIGABRT, 128 + SIGABRT):
+                _, stderr = proc.communicate(timeout=5)
+                stderr_text = stderr.decode("utf-8", errors="replace") if stderr else ""
+                pytest.fail(
+                    f"FreeCAD crashed during SIGTERM shutdown (exit code {exit_code}).\n"
+                    f"stderr: {stderr_text[:1000]}"
+                )
+
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+
+
+# Standalone test runner for manual testing
+if __name__ == "__main__":
+    """Run the shutdown crash test manually.
+
+    Usage:
+        python tests/integration/test_shutdown_crash.py
+    """
+    binary = _find_freecad_binary()
+    if not binary:
+        print("ERROR: FreeCAD binary not found")
+        sys.exit(1)
+
+    tests_dir = Path(__file__).parent
+    project_root = tests_dir.parent.parent
+    script = str(
+        project_root
+        / "freecad"
+        / "RobustMCPBridge"
+        / "freecad_mcp_bridge"
+        / "startup_bridge.py"
+    )
+
+    print(f"FreeCAD binary: {binary}")
+    print(f"Startup script: {script}")
+    print()
+
+    print("Starting FreeCAD with MCP bridge...")
+    env = os.environ.copy()
+    env["FREECAD_MCP_TESTING"] = "1"
+
+    # S603: Safe - binary is from _find_freecad_binary(), not user input
+    proc = subprocess.Popen(  # noqa: S603
+        [binary, script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+    print("Waiting for bridge to be ready...")
+    if not _wait_for_bridge(timeout=60.0):
+        print("ERROR: Bridge did not become available")
+        proc.terminate()
+        proc.wait()
+        sys.exit(1)
+
+    print("Bridge is ready!")
+    print("Waiting 3 seconds for stabilization...")
+    time.sleep(3)
+
+    print("Sending quit command...")
+    _send_quit_command()
+
+    print("Waiting for FreeCAD to exit...")
+    try:
+        exit_code = proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        print("Timeout - killing process")
+        proc.kill()
+        exit_code = proc.wait()
+
+    print(f"Exit code: {exit_code}")
+
+    if exit_code in CRASH_EXIT_CODES:
+        print("CRASH DETECTED!")
+        _, stderr = proc.communicate(timeout=5)
+        if stderr:
+            print("stderr:", stderr.decode("utf-8", errors="replace")[:2000])
+        sys.exit(1)
+    else:
+        print("Clean shutdown - no crash!")
+        sys.exit(0)

--- a/tests/just_commands/test_testing.py
+++ b/tests/just_commands/test_testing.py
@@ -82,3 +82,70 @@ class TestTestingRuntime:
             env={"PYTEST_ADDOPTS": "--collect-only -q"},
         )
         assert_command_executed(result, "testing::quick")
+
+    @pytest.mark.just_runtime
+    def test_gui_release_sequencing(self, just: JustRunner) -> None:
+        """integration-gui-release recipe follows the correct shutdown sequence.
+
+        After stopping FreeCAD, the recipe must:
+        1. Call cleanup (graceful_kill_bridge_ports)
+        2. Set STARTED_FREECAD=false
+        3. Call wait_for_ports_free
+        4. Call wait_for_freecad_exit
+        5. Only run standalone tests when TEST_EXIT_CODE is 0
+        6. Target test_shutdown_crash.py specifically for standalone tests
+        7. Use -m "not standalone_freecad" for the first pytest run
+        """
+        result = just.dry_run("testing::integration-gui-release")
+        assert result.success, (
+            f"Dry-run failed for integration-gui-release: {result.stderr}"
+        )
+
+        # just --dry-run writes the expanded script to stderr
+        script = result.output
+
+        # --- Verify first pytest run filters out standalone tests ---
+        assert '-m "not standalone_freecad"' in script, (
+            "First pytest run must exclude standalone_freecad tests"
+        )
+
+        # --- Verify shutdown sequence order ---
+        # Find positions of critical operations after stopping FreeCAD.
+        # Use the "Stopping FreeCAD" marker to anchor past the function
+        # definition, trap registrations, and comments that also mention cleanup.
+        stopMarker = "Stopping FreeCAD for standalone tests"
+        assert stopMarker in script, (
+            "Recipe must log 'Stopping FreeCAD for standalone tests'"
+        )
+        stopPos = script.index(stopMarker)
+        cleanupPos = script.index("cleanup", stopPos)
+        startedFalsePos = script.index("STARTED_FREECAD=false", stopPos)
+        portsPos = script.index("wait_for_ports_free", stopPos)
+        exitPos = script.index("wait_for_freecad_exit", stopPos)
+
+        assert cleanupPos < startedFalsePos, (
+            "cleanup must be called before STARTED_FREECAD=false"
+        )
+        assert startedFalsePos < portsPos, (
+            "STARTED_FREECAD=false must be set before wait_for_ports_free"
+        )
+        assert portsPos < exitPos, (
+            "wait_for_ports_free must be called before wait_for_freecad_exit"
+        )
+
+        # --- Verify standalone tests are conditional on prior success ---
+        standaloneGuard = 'if [ "$TEST_EXIT_CODE" -eq 0 ]'
+        assert standaloneGuard in script, (
+            "Standalone tests must be guarded by TEST_EXIT_CODE == 0 check"
+        )
+
+        # The standalone pytest must target test_shutdown_crash.py specifically
+        assert "test_shutdown_crash.py" in script, (
+            "Standalone pytest must target test_shutdown_crash.py"
+        )
+
+        # The guard must appear after wait_for_freecad_exit
+        guardPos = script.index(standaloneGuard)
+        assert guardPos > exitPos, (
+            "Standalone test guard must come after wait_for_freecad_exit"
+        )

--- a/tests/just_commands/test_testing.py
+++ b/tests/just_commands/test_testing.py
@@ -85,17 +85,7 @@ class TestTestingRuntime:
 
     @pytest.mark.just_runtime
     def test_gui_release_sequencing(self, just: JustRunner) -> None:
-        """integration-gui-release recipe follows the correct shutdown sequence.
-
-        After stopping FreeCAD, the recipe must:
-        1. Call cleanup (graceful_kill_bridge_ports)
-        2. Set STARTED_FREECAD=false
-        3. Call wait_for_ports_free
-        4. Call wait_for_freecad_exit
-        5. Only run standalone tests when TEST_EXIT_CODE is 0
-        6. Target test_shutdown_crash.py specifically for standalone tests
-        7. Use -m "not standalone_freecad" for the first pytest run
-        """
+        """Verify integration-gui-release shutdown sequencing and standalone test selection."""
         result = just.dry_run("testing::integration-gui-release")
         assert result.success, (
             f"Dry-run failed for integration-gui-release: {result.stderr}"

--- a/tests/just_commands/test_testing.py
+++ b/tests/just_commands/test_testing.py
@@ -104,14 +104,22 @@ class TestTestingRuntime:
         # Use the "Stopping FreeCAD" marker to anchor past the function
         # definition, trap registrations, and comments that also mention cleanup.
         stopMarker = "Stopping FreeCAD for standalone tests"
-        assert stopMarker in script, (
-            "Recipe must log 'Stopping FreeCAD for standalone tests'"
+        stopPos = script.find(stopMarker)
+        assert stopPos != -1, "Recipe must log 'Stopping FreeCAD for standalone tests'"
+
+        cleanupPos = script.find("cleanup", stopPos)
+        assert cleanupPos != -1, "cleanup call not found after stop marker"
+
+        startedFalsePos = script.find("STARTED_FREECAD=false", stopPos)
+        assert startedFalsePos != -1, (
+            "STARTED_FREECAD=false not found after stop marker"
         )
-        stopPos = script.index(stopMarker)
-        cleanupPos = script.index("cleanup", stopPos)
-        startedFalsePos = script.index("STARTED_FREECAD=false", stopPos)
-        portsPos = script.index("wait_for_ports_free", stopPos)
-        exitPos = script.index("wait_for_freecad_exit", stopPos)
+
+        portsPos = script.find("wait_for_ports_free", stopPos)
+        assert portsPos != -1, "wait_for_ports_free not found after stop marker"
+
+        exitPos = script.find("wait_for_freecad_exit", stopPos)
+        assert exitPos != -1, "wait_for_freecad_exit not found after stop marker"
 
         assert cleanupPos < startedFalsePos, (
             "cleanup must be called before STARTED_FREECAD=false"
@@ -135,7 +143,8 @@ class TestTestingRuntime:
         )
 
         # The guard must appear after wait_for_freecad_exit
-        guardPos = script.index(standaloneGuard)
+        guardPos = script.find(standaloneGuard)
+        assert guardPos != -1, "TEST_EXIT_CODE guard not found in script"
         assert guardPos > exitPos, (
             "Standalone test guard must come after wait_for_freecad_exit"
         )

--- a/tests/unit/test_workbench_cleanup.py
+++ b/tests/unit/test_workbench_cleanup.py
@@ -21,6 +21,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _clear_bridge_cache() -> None:
+    """Remove cached freecad_mcp_bridge imports so the module is re-imported fresh."""
+    for mod_name in list(sys.modules.keys()):
+        if "freecad_mcp_bridge" in mod_name:
+            del sys.modules[mod_name]
+
+
 class TestCleanupForExit:
     """Tests for _cleanup_for_exit method."""
 
@@ -82,18 +89,10 @@ class TestCleanupForExit:
         This is critical because during Python finalization, the main window
         may already be destroyed by Qt, causing a crash.
         """
-        # Import after mocking to get mocked FreeCAD
-        # We need to reload or import fresh
+        _clear_bridge_cache()
 
-        # Remove any cached imports
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
-
-        # Now import the plugin module
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
-        # Create a plugin instance
         plugin = server.FreecadMCPPlugin()
 
         # Simulate having started (timers exist)
@@ -105,7 +104,6 @@ class TestCleanupForExit:
         # Reset the mock to clear any previous calls
         mock_qt_env["FreeCADGui"].reset_mock()
 
-        # Call the cleanup method
         plugin._cleanup_for_exit()
 
         # Verify that getMainWindow was NOT called
@@ -117,11 +115,7 @@ class TestCleanupForExit:
         _set_status_bar accesses the main window's status bar, which crashes
         during Python finalization.
         """
-
-        # Remove any cached imports
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+        _clear_bridge_cache()
 
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
@@ -133,7 +127,6 @@ class TestCleanupForExit:
         # Spy on _set_status_bar
         plugin._set_status_bar = MagicMock()  # type: ignore[method-assign]
 
-        # Call cleanup
         plugin._cleanup_for_exit()
 
         # Verify _set_status_bar was NOT called
@@ -141,23 +134,18 @@ class TestCleanupForExit:
 
     def test_cleanup_for_exit_stops_timers(self, mock_qt_env):
         """_cleanup_for_exit should stop QTimer objects."""
-
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+        _clear_bridge_cache()
 
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
         plugin = server.FreecadMCPPlugin()
 
-        # Create mock timers
         mock_queue_timer = MagicMock()
         mock_status_timer = MagicMock()
         plugin._timer = mock_queue_timer  # type: ignore[assignment]
         plugin._status_timer = mock_status_timer  # type: ignore[assignment]
         plugin._running = True
 
-        # Call cleanup
         plugin._cleanup_for_exit()
 
         # Verify timers were stopped
@@ -170,10 +158,7 @@ class TestCleanupForExit:
 
     def test_cleanup_for_exit_disconnects_timer_signals(self, mock_qt_env):
         """_cleanup_for_exit should disconnect timer signals."""
-
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+        _clear_bridge_cache()
 
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
@@ -203,10 +188,7 @@ class TestCleanupForExit:
         marking the PySide wrapper as invalid so Python's GC won't try to
         destroy it again.
         """
-
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+        _clear_bridge_cache()
 
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
@@ -236,10 +218,7 @@ class TestCleanupForExit:
         deletion for the next event loop iteration, but the event loop
         isn't running during atexit.
         """
-
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+        _clear_bridge_cache()
 
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
@@ -259,10 +238,7 @@ class TestCleanupForExit:
 
     def test_cleanup_for_exit_sets_running_false(self, mock_qt_env):
         """_cleanup_for_exit should set _running to False."""
-
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+        _clear_bridge_cache()
 
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
@@ -273,9 +249,45 @@ class TestCleanupForExit:
 
         assert plugin._running is False
 
+    def test_cleanup_for_exit_safe_when_no_timers(self, mock_qt_env):
+        """_cleanup_for_exit should be safe when no timers exist (headless mode)."""
+        _clear_bridge_cache()
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+        # Simulate headless mode: no timers were created
+        plugin._timer = None
+        plugin._status_timer = None
+        plugin._running = True
+
+        # Should not raise
+        plugin._cleanup_for_exit()
+
+        assert plugin._running is False
+
+    def test_cleanup_for_exit_idempotent(self, mock_qt_env):
+        """_cleanup_for_exit should be safe to call multiple times."""
+        _clear_bridge_cache()
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+        plugin._timer = MagicMock()  # type: ignore[assignment]
+        plugin._status_timer = MagicMock()  # type: ignore[assignment]
+        plugin._running = True
+
+        # Call twice - should not raise
+        plugin._cleanup_for_exit()
+        plugin._cleanup_for_exit()
+
+        assert plugin._running is False
+        assert plugin._timer is None
+        assert plugin._status_timer is None
+
 
 class TestAtexitHandler:
-    """Tests for the atexit cleanup handler."""
+    """Tests for the atexit cleanup handler (_cleanup_all_servers)."""
 
     @pytest.fixture
     def mock_freecad_env(self):
@@ -303,45 +315,38 @@ class TestAtexitHandler:
                 "FreeCADGui": mock_freecadgui,
             }
 
-    def test_cleanup_all_servers_calls_cleanup_for_exit(self, mock_freecad_env):
-        """_cleanup_all_servers should call _cleanup_for_exit, not stop()."""
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+    @pytest.fixture
+    def fresh_server_module(self, mock_freecad_env):
+        """Import a fresh server module and yield it, cleaning up _activeServers after."""
+        _clear_bridge_cache()
 
         from freecad.RobustMCPBridge.freecad_mcp_bridge import server
 
-        # Create a plugin and add it to the active servers set
+        yield server
+
+        # Clean up any servers we added during the test
+        server._activeServers.clear()
+
+    def test_cleanup_all_servers_calls_cleanup_for_exit(self, fresh_server_module):
+        """_cleanup_all_servers should call _cleanup_for_exit, not stop()."""
+        server = fresh_server_module
+
         plugin = server.FreecadMCPPlugin()
         plugin._running = True
-
-        # Spy on the methods
         plugin._cleanup_for_exit = MagicMock()  # type: ignore[method-assign]
         plugin.stop = MagicMock()  # type: ignore[method-assign]
 
-        # Add to active servers
-        server._active_servers.add(plugin)
+        server._activeServers.add(plugin)
 
-        try:
-            # Call the cleanup function
-            server._cleanup_all_servers()
+        server._cleanup_all_servers()
 
-            # Verify _cleanup_for_exit was called, not stop()
-            plugin._cleanup_for_exit.assert_called_once()
-            plugin.stop.assert_not_called()
-        finally:
-            # Clean up
-            server._active_servers.discard(plugin)
+        plugin._cleanup_for_exit.assert_called_once()
+        plugin.stop.assert_not_called()
 
-    def test_cleanup_all_servers_handles_exceptions(self, mock_freecad_env):
+    def test_cleanup_all_servers_handles_exceptions(self, fresh_server_module):
         """_cleanup_all_servers should continue even if one server raises."""
-        for mod_name in list(sys.modules.keys()):
-            if "freecad_mcp_bridge" in mod_name:
-                del sys.modules[mod_name]
+        server = fresh_server_module
 
-        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
-
-        # Create two plugins
         plugin1 = server.FreecadMCPPlugin()
         plugin1._running = True
         plugin1._cleanup_for_exit = MagicMock(  # type: ignore[method-assign]
@@ -352,16 +357,177 @@ class TestAtexitHandler:
         plugin2._running = True
         plugin2._cleanup_for_exit = MagicMock()  # type: ignore[method-assign]
 
-        server._active_servers.add(plugin1)
-        server._active_servers.add(plugin2)
+        server._activeServers.add(plugin1)
+        server._activeServers.add(plugin2)
 
-        try:
-            # Should not raise even though plugin1 raises
-            server._cleanup_all_servers()
+        # Should not raise even though plugin1 raises
+        server._cleanup_all_servers()
 
-            # Both should have been attempted
-            plugin1._cleanup_for_exit.assert_called_once()
-            plugin2._cleanup_for_exit.assert_called_once()
-        finally:
-            server._active_servers.discard(plugin1)
-            server._active_servers.discard(plugin2)
+        # Both should have been attempted
+        plugin1._cleanup_for_exit.assert_called_once()
+        plugin2._cleanup_for_exit.assert_called_once()
+
+    def test_cleanup_all_servers_calls_non_running_servers(self, fresh_server_module):
+        """_cleanup_all_servers should call _cleanup_for_exit even when _running is False.
+
+        A server may have timers allocated from a failed startup that still
+        need explicit shiboken.delete() to avoid GC crashes.
+        """
+        server = fresh_server_module
+
+        plugin = server.FreecadMCPPlugin()
+        plugin._running = False  # Simulate failed startup
+        plugin._cleanup_for_exit = MagicMock()  # type: ignore[method-assign]
+
+        server._activeServers.add(plugin)
+
+        server._cleanup_all_servers()
+
+        # _cleanup_for_exit should still be called
+        plugin._cleanup_for_exit.assert_called_once()
+
+    def test_cleanup_all_servers_empty_set(self, fresh_server_module):
+        """_cleanup_all_servers should be safe with no active servers."""
+        server = fresh_server_module
+        server._activeServers.clear()
+
+        # Should not raise
+        server._cleanup_all_servers()
+
+    def test_cleanup_all_servers_iterates_safely_during_modification(
+        self, fresh_server_module
+    ):
+        """_cleanup_all_servers should iterate a snapshot, not the live set.
+
+        The function calls list(_activeServers) to snapshot before iterating,
+        so modifications to _activeServers during cleanup don't cause errors.
+        """
+        server = fresh_server_module
+
+        plugin1 = server.FreecadMCPPlugin()
+        plugin1._running = True
+        plugin2 = server.FreecadMCPPlugin()
+        plugin2._running = True
+
+        # Make plugin1's cleanup remove plugin2 from _activeServers
+        def remove_plugin2() -> None:
+            server._activeServers.discard(plugin2)
+
+        plugin1._cleanup_for_exit = MagicMock(  # type: ignore[method-assign]
+            side_effect=remove_plugin2
+        )
+        plugin2._cleanup_for_exit = MagicMock()  # type: ignore[method-assign]
+
+        server._activeServers.add(plugin1)
+        server._activeServers.add(plugin2)
+
+        # Should not raise RuntimeError: Set changed size during iteration
+        server._cleanup_all_servers()
+
+        # Both should have been attempted (snapshot was taken before iteration)
+        plugin1._cleanup_for_exit.assert_called_once()
+        plugin2._cleanup_for_exit.assert_called_once()
+
+    def test_cleanup_all_servers_multiple_exception_sources(self, fresh_server_module):
+        """_cleanup_all_servers should handle ALL servers raising exceptions."""
+        server = fresh_server_module
+
+        plugin1 = server.FreecadMCPPlugin()
+        plugin1._running = True
+        plugin1._cleanup_for_exit = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("Error 1")
+        )
+
+        plugin2 = server.FreecadMCPPlugin()
+        plugin2._running = True
+        plugin2._cleanup_for_exit = MagicMock(  # type: ignore[method-assign]
+            side_effect=TypeError("Error 2")
+        )
+
+        server._activeServers.add(plugin1)
+        server._activeServers.add(plugin2)
+
+        # Should not raise even when every server raises
+        server._cleanup_all_servers()
+
+        plugin1._cleanup_for_exit.assert_called_once()
+        plugin2._cleanup_for_exit.assert_called_once()
+
+
+class TestAtexitRegistration:
+    """Tests for atexit handler registration during FreecadMCPPlugin.__init__."""
+
+    @pytest.fixture
+    def mock_freecad_env(self):
+        """Set up mocked FreeCAD environment."""
+        mock_freecad = MagicMock()
+        mock_freecad.GuiUp = True
+        mock_freecad.Console = MagicMock()
+        mock_freecadgui = MagicMock()
+
+        with patch.dict(
+            sys.modules,
+            {
+                "FreeCAD": mock_freecad,
+                "FreeCADGui": mock_freecadgui,
+                "PySide2": MagicMock(),
+                "PySide2.QtCore": MagicMock(),
+                "PySide6": MagicMock(),
+                "PySide6.QtCore": MagicMock(),
+                "shiboken6": MagicMock(),
+            },
+        ):
+            yield
+
+    def test_plugin_added_to_active_servers(self, mock_freecad_env):
+        """Creating a plugin should register it in _activeServers."""
+        _clear_bridge_cache()
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        initial_count = len(server._activeServers)
+        plugin = server.FreecadMCPPlugin()
+
+        assert plugin in server._activeServers
+        assert len(server._activeServers) >= initial_count + 1
+
+        server._activeServers.discard(plugin)
+
+    def test_atexit_registered_once(self, mock_freecad_env):
+        """atexit.register should be called at most once across multiple plugins."""
+        _clear_bridge_cache()
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        # Reset the flag to test fresh registration
+        server._atexitRegistered = False
+
+        with patch("atexit.register") as mock_register:
+            _ = server.FreecadMCPPlugin()
+            _ = server.FreecadMCPPlugin()
+
+            # Should only register once
+            mock_register.assert_called_once_with(server._cleanup_all_servers)
+
+        server._activeServers.clear()
+
+    def test_weak_reference_allows_gc(self, mock_freecad_env):
+        """_activeServers uses WeakSet, so unreferenced plugins can be GC'd."""
+        _clear_bridge_cache()
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+        assert plugin in server._activeServers
+
+        # Remove the only strong reference—WeakSet should let it be collected
+        plugin_id = id(plugin)
+        del plugin
+
+        # The plugin should no longer be in the set (may need GC nudge)
+        import gc
+
+        gc.collect()
+
+        remaining_ids = [id(s) for s in server._activeServers]
+        assert plugin_id not in remaining_ids

--- a/tests/unit/test_workbench_cleanup.py
+++ b/tests/unit/test_workbench_cleanup.py
@@ -1,0 +1,367 @@
+"""Tests for workbench bridge cleanup during Python exit.
+
+These tests verify that the MCP bridge plugin properly cleans up during
+Python finalization (atexit handlers) without accessing destroyed GUI elements.
+
+The key issue: During Python's Py_FinalizeEx(), the garbage collector tries to
+finalize PySide QTimer wrapper objects. This triggers Qt's disconnectNotify
+callback which tries to do Python operations on a partially-finalized interpreter,
+causing a SIGSEGV crash.
+
+The fix uses shiboken.delete() to explicitly destroy the C++ QTimer objects
+BEFORE Python's GC runs, which marks the PySide wrappers as invalid so the
+GC won't try to destroy them again.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCleanupForExit:
+    """Tests for _cleanup_for_exit method."""
+
+    @pytest.fixture
+    def mock_freecad_env(self):
+        """Set up mocked FreeCAD environment for testing plugin code."""
+        # Create mock modules
+        mock_freecad = MagicMock()
+        mock_freecad.GuiUp = True
+        mock_freecad.Console = MagicMock()
+
+        mock_freecadgui = MagicMock()
+
+        # Patch the imports before importing the plugin module
+        with patch.dict(
+            sys.modules,
+            {
+                "FreeCAD": mock_freecad,
+                "FreeCADGui": mock_freecadgui,
+            },
+        ):
+            yield {
+                "FreeCAD": mock_freecad,
+                "FreeCADGui": mock_freecadgui,
+            }
+
+    @pytest.fixture
+    def mock_qt_env(self, mock_freecad_env):
+        """Set up mocked Qt environment with shiboken."""
+        mock_qtcore = MagicMock()
+        mock_timer = MagicMock()
+        mock_qtcore.QTimer.return_value = mock_timer
+
+        # Mock shiboken delete function
+        mock_shiboken_delete = MagicMock()
+        mock_shiboken6 = MagicMock()
+        mock_shiboken6.delete = mock_shiboken_delete
+
+        with patch.dict(
+            sys.modules,
+            {
+                "PySide2": MagicMock(),
+                "PySide2.QtCore": mock_qtcore,
+                "PySide6": MagicMock(),
+                "PySide6.QtCore": mock_qtcore,
+                "shiboken6": mock_shiboken6,
+            },
+        ):
+            yield {
+                **mock_freecad_env,
+                "QtCore": mock_qtcore,
+                "timer": mock_timer,
+                "shiboken_delete": mock_shiboken_delete,
+            }
+
+    def test_cleanup_for_exit_does_not_access_main_window(self, mock_qt_env):
+        """_cleanup_for_exit should NOT call FreeCADGui.getMainWindow().
+
+        This is critical because during Python finalization, the main window
+        may already be destroyed by Qt, causing a crash.
+        """
+        # Import after mocking to get mocked FreeCAD
+        # We need to reload or import fresh
+
+        # Remove any cached imports
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        # Now import the plugin module
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        # Create a plugin instance
+        plugin = server.FreecadMCPPlugin()
+
+        # Simulate having started (timers exist)
+        mock_timer = MagicMock()
+        plugin._timer = mock_timer  # type: ignore[assignment]
+        plugin._status_timer = MagicMock()  # type: ignore[assignment]
+        plugin._running = True
+
+        # Reset the mock to clear any previous calls
+        mock_qt_env["FreeCADGui"].reset_mock()
+
+        # Call the cleanup method
+        plugin._cleanup_for_exit()
+
+        # Verify that getMainWindow was NOT called
+        mock_qt_env["FreeCADGui"].getMainWindow.assert_not_called()
+
+    def test_cleanup_for_exit_does_not_call_set_status_bar(self, mock_qt_env):
+        """_cleanup_for_exit should NOT call _set_status_bar().
+
+        _set_status_bar accesses the main window's status bar, which crashes
+        during Python finalization.
+        """
+
+        # Remove any cached imports
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+        plugin._timer = MagicMock()  # type: ignore[assignment]
+        plugin._status_timer = MagicMock()  # type: ignore[assignment]
+        plugin._running = True
+
+        # Spy on _set_status_bar
+        plugin._set_status_bar = MagicMock()  # type: ignore[method-assign]
+
+        # Call cleanup
+        plugin._cleanup_for_exit()
+
+        # Verify _set_status_bar was NOT called
+        plugin._set_status_bar.assert_not_called()
+
+    def test_cleanup_for_exit_stops_timers(self, mock_qt_env):
+        """_cleanup_for_exit should stop QTimer objects."""
+
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+
+        # Create mock timers
+        mock_queue_timer = MagicMock()
+        mock_status_timer = MagicMock()
+        plugin._timer = mock_queue_timer  # type: ignore[assignment]
+        plugin._status_timer = mock_status_timer  # type: ignore[assignment]
+        plugin._running = True
+
+        # Call cleanup
+        plugin._cleanup_for_exit()
+
+        # Verify timers were stopped
+        mock_queue_timer.stop.assert_called_once()
+        mock_status_timer.stop.assert_called_once()
+
+        # Verify references are cleared
+        assert plugin._timer is None
+        assert plugin._status_timer is None
+
+    def test_cleanup_for_exit_disconnects_timer_signals(self, mock_qt_env):
+        """_cleanup_for_exit should disconnect timer signals."""
+
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+
+        mock_queue_timer = MagicMock()
+        mock_status_timer = MagicMock()
+        plugin._timer = mock_queue_timer  # type: ignore[assignment]
+        plugin._status_timer = mock_status_timer  # type: ignore[assignment]
+        plugin._running = True
+
+        plugin._cleanup_for_exit()
+
+        # Verify signals were disconnected
+        mock_queue_timer.timeout.disconnect.assert_called_once()
+        mock_status_timer.timeout.disconnect.assert_called_once()
+
+    def test_cleanup_for_exit_uses_shiboken_delete(self, mock_qt_env):
+        """_cleanup_for_exit should use shiboken.delete() to destroy Qt objects.
+
+        This is CRITICAL: deleteLater() doesn't work during shutdown because
+        it schedules deletion for the next event loop iteration, which never
+        happens. Python's GC then tries to finalize the PySide wrapper, which
+        triggers Qt's disconnectNotify callback into partially-finalized Python.
+
+        Using shiboken.delete() explicitly destroys the C++ object immediately,
+        marking the PySide wrapper as invalid so Python's GC won't try to
+        destroy it again.
+        """
+
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+
+        mock_queue_timer = MagicMock()
+        mock_status_timer = MagicMock()
+        plugin._timer = mock_queue_timer  # type: ignore[assignment]
+        plugin._status_timer = mock_status_timer  # type: ignore[assignment]
+        plugin._running = True
+
+        # Reset the mock to track calls during cleanup
+        mock_qt_env["shiboken_delete"].reset_mock()
+
+        plugin._cleanup_for_exit()
+
+        # Verify shiboken.delete() was called for both timers
+        assert mock_qt_env["shiboken_delete"].call_count == 2
+        calls = [call[0][0] for call in mock_qt_env["shiboken_delete"].call_args_list]
+        assert mock_queue_timer in calls
+        assert mock_status_timer in calls
+
+    def test_cleanup_for_exit_does_not_use_delete_later(self, mock_qt_env):
+        """_cleanup_for_exit should NOT use deleteLater().
+
+        deleteLater() is the source of the crash because it schedules
+        deletion for the next event loop iteration, but the event loop
+        isn't running during atexit.
+        """
+
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+
+        mock_queue_timer = MagicMock()
+        mock_status_timer = MagicMock()
+        plugin._timer = mock_queue_timer  # type: ignore[assignment]
+        plugin._status_timer = mock_status_timer  # type: ignore[assignment]
+        plugin._running = True
+
+        plugin._cleanup_for_exit()
+
+        # Verify deleteLater was NOT called
+        mock_queue_timer.deleteLater.assert_not_called()
+        mock_status_timer.deleteLater.assert_not_called()
+
+    def test_cleanup_for_exit_sets_running_false(self, mock_qt_env):
+        """_cleanup_for_exit should set _running to False."""
+
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        plugin = server.FreecadMCPPlugin()
+        plugin._running = True
+
+        plugin._cleanup_for_exit()
+
+        assert plugin._running is False
+
+
+class TestAtexitHandler:
+    """Tests for the atexit cleanup handler."""
+
+    @pytest.fixture
+    def mock_freecad_env(self):
+        """Set up mocked FreeCAD environment."""
+        mock_freecad = MagicMock()
+        mock_freecad.GuiUp = True
+        mock_freecad.Console = MagicMock()
+
+        mock_freecadgui = MagicMock()
+
+        with patch.dict(
+            sys.modules,
+            {
+                "FreeCAD": mock_freecad,
+                "FreeCADGui": mock_freecadgui,
+                "PySide2": MagicMock(),
+                "PySide2.QtCore": MagicMock(),
+                "PySide6": MagicMock(),
+                "PySide6.QtCore": MagicMock(),
+                "shiboken6": MagicMock(),
+            },
+        ):
+            yield {
+                "FreeCAD": mock_freecad,
+                "FreeCADGui": mock_freecadgui,
+            }
+
+    def test_cleanup_all_servers_calls_cleanup_for_exit(self, mock_freecad_env):
+        """_cleanup_all_servers should call _cleanup_for_exit, not stop()."""
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        # Create a plugin and add it to the active servers set
+        plugin = server.FreecadMCPPlugin()
+        plugin._running = True
+
+        # Spy on the methods
+        plugin._cleanup_for_exit = MagicMock()  # type: ignore[method-assign]
+        plugin.stop = MagicMock()  # type: ignore[method-assign]
+
+        # Add to active servers
+        server._active_servers.add(plugin)
+
+        try:
+            # Call the cleanup function
+            server._cleanup_all_servers()
+
+            # Verify _cleanup_for_exit was called, not stop()
+            plugin._cleanup_for_exit.assert_called_once()
+            plugin.stop.assert_not_called()
+        finally:
+            # Clean up
+            server._active_servers.discard(plugin)
+
+    def test_cleanup_all_servers_handles_exceptions(self, mock_freecad_env):
+        """_cleanup_all_servers should continue even if one server raises."""
+        for mod_name in list(sys.modules.keys()):
+            if "freecad_mcp_bridge" in mod_name:
+                del sys.modules[mod_name]
+
+        from freecad.RobustMCPBridge.freecad_mcp_bridge import server
+
+        # Create two plugins
+        plugin1 = server.FreecadMCPPlugin()
+        plugin1._running = True
+        plugin1._cleanup_for_exit = MagicMock(  # type: ignore[method-assign]
+            side_effect=Exception("Test error")
+        )
+
+        plugin2 = server.FreecadMCPPlugin()
+        plugin2._running = True
+        plugin2._cleanup_for_exit = MagicMock()  # type: ignore[method-assign]
+
+        server._active_servers.add(plugin1)
+        server._active_servers.add(plugin2)
+
+        try:
+            # Should not raise even though plugin1 raises
+            server._cleanup_all_servers()
+
+            # Both should have been attempted
+            plugin1._cleanup_for_exit.assert_called_once()
+            plugin2._cleanup_for_exit.assert_called_once()
+        finally:
+            server._active_servers.discard(plugin1)
+            server._active_servers.discard(plugin2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer shutdown: improved exit-time cleanup to avoid Qt/PySide finalization crashes.

* **Improvements**
  * Better lifecycle and atexit handling for bridge instances; environment flag to disable auto-start in tests.
  * Broader .log ignore rule.

* **Tests**
  * New unit and integration tests to detect shutdown crashes and validate cleanup behavior.

* **Chores**
  * CI/test flow updated to conditionally run standalone shutdown tests after successful GUI runs; added scripts to wait for ports/processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->