### PR TITLE
fix: HTTP transport broken with MCP SDK v1.25.0

### DIFF
--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -426,11 +426,10 @@ def main() -> None:
     # Run the server
     if config.transport == TransportType.HTTP:
         logger.info("Starting HTTP transport on port %d", config.http_port)
-        mcp.run(  # type: ignore[call-arg]
-            transport="streamable-http",
-            host="0.0.0.0",  # noqa: S104
-            port=config.http_port,
-        )
+        mcp.settings.host = "0.0.0.0"  # noqa: S104
+        mcp.settings.port = config.http_port
+        mcp.run(transport="streamable-http")
+
     else:
         logger.info("Starting stdio transport")
         logger.info(


### PR DESCRIPTION
## Bug

When using `FREECAD_TRANSPORT=http`, the server crashes immediately with:

```
TypeError: FastMCP.run() got an unexpected keyword argument 'host'
```

This happens because `server.py` passes `host` and `port` as kwargs to
`mcp.run()`, but in MCP SDK v1.25.0, `FastMCP.run()` only accepts
`transport` and `mount_path`. The host/port must be set on `mcp.settings`
before calling `run()`.

## Fix

Replace the `mcp.run()` call in the HTTP branch of `main()` with:

```python
mcp.settings.host = "0.0.0.0"  # noqa: S104
mcp.settings.port = config.http_port
mcp.run(transport="streamable-http")
```

This approach correctly reads `config` inside `main()`, after
`apply_cli_args_to_env()` has been called, so CLI args like `--http-port`
are properly applied before the server starts.

## Environment

Tested in two different setups:

---

**Setup 1 — Dockerized FreeCAD on Synology NAS:**

- Hardware: Synology NAS (DSM 7.x)
- Client: Claude Desktop v1.1.3189.0 on Windows 11, connecting remotely
  via `npx mcp-remote --allow-http`

`linuxserver-freecad` container (FreeCAD with Robust MCP Bridge):

```yaml
services:
  freecad:
    image: lscr.io/linuxserver/freecad:1.0.2-ls120
    container_name: linuxserver-freecad
    ports:
      - 3935:3001   # http
      - 3936:3000   # https
      - 3937:8082   # websockets
      - 9875:9875   # XML-RPC  (Robust MCP Bridge addon)
      - 9876:9876   # JSON-RPC (Robust MCP Bridge addon)
    environment:
      TZ: Europe/Madrid
    restart: on-failure:3
```

`freecad-mcp` container (this project, with HTTP transport):

```yaml
services:
  freecad-mcp:
    image: spkane/freecad-robust-mcp:latest
    container_name: freecad-mcp
    environment:
      FREECAD_MODE: xmlrpc
      FREECAD_SOCKET_HOST: 192.168.1.100   # Synology IP
      FREECAD_XMLRPC_PORT: 9875
      FREECAD_TIMEOUT_MS: 30000
      FREECAD_TRANSPORT: http
      FREECAD_HTTP_PORT: 8000
      TZ: Europe/Madrid
    ports:
      - "8100:8000"
    restart: on-failure:5
```

---

**Setup 2 — Native FreeCAD on Windows laptop:**

- FreeCAD 1.0.2 installed natively on Windows 11 with Robust MCP Bridge
  addon enabled, XML-RPC listening on `0.0.0.0:9875`
- `freecad-mcp` container on Synology NAS connecting to FreeCAD on the
  Windows machine via XML-RPC over LAN (`FREECAD_SOCKET_HOST=<laptop IP>`)
- Client: Claude Desktop v1.1.3189.0 on the same Windows machine

---

**Common stack:**
- MCP SDK: v1.25.0
- `freecad-robust-mcp` image: v0.6.2 (`spkane/freecad-robust-mcp:latest`)
- Docker running on Synology NAS (Linux 4.4.302, DSM 7.x)

In both setups, HTTP transport fails without this fix and works correctly
after applying it.

## Workaround (until fix is merged)

As a temporary workaround, a patched image can be built locally with this
`Dockerfile`:

```dockerfile
FROM spkane/freecad-robust-mcp:latest
USER root
COPY patch_server.py /tmp/patch_server.py
RUN python3 /tmp/patch_server.py && rm /tmp/patch_server.py
USER nobody
```
