### PR TITLE
fix: Use type() instead of __class__ for FreeCAD C++ binding objects

### DIFF
--- a/src/freecad_mcp/bridge/embedded.py
+++ b/src/freecad_mcp/bridge/embedded.py
@@ -251,7 +251,7 @@ props = {{}}
 for prop in obj.PropertiesList:
     try:
         val = getattr(obj, prop)
-        if hasattr(val, '__class__') and val.__class__.__module__ != 'builtins':
+        if type(val).__module__ != 'builtins':
             val = str(val)
         props[prop] = val
     except Exception:
@@ -1017,7 +1017,7 @@ import FreeCADGui
         code = """
 workbenches = []
 active_wb = FreeCADGui.activeWorkbench()
-active_name = active_wb.__class__.__name__ if active_wb else None
+active_name = type(active_wb).__name__ if active_wb else None
 
 for name in FreeCADGui.listWorkbenches():
     wb = FreeCADGui.getWorkbench(name)

--- a/src/freecad_mcp/bridge/socket.py
+++ b/src/freecad_mcp/bridge/socket.py
@@ -529,7 +529,7 @@ props = {{}}
 for prop in obj.PropertiesList:
     try:
         val = getattr(obj, prop)
-        if hasattr(val, '__class__') and val.__class__.__module__ != 'builtins':
+        if type(val).__module__ != 'builtins':
             val = str(val)
         props[prop] = val
     except Exception:
@@ -703,7 +703,7 @@ if view is None:
     raise ValueError("No active view")
 
 # Check view type
-view_type = view.__class__.__name__
+view_type = type(view).__name__
 if view_type not in ["View3DInventor", "View3DInventorPy"]:
     raise ValueError(f"Cannot capture screenshot from {{view_type}} view")
 
@@ -953,7 +953,7 @@ _result_ = {{
         code = """
 workbenches = []
 active_wb = FreeCADGui.activeWorkbench() if FreeCAD.GuiUp else None
-active_name = active_wb.__class__.__name__ if active_wb else None
+active_name = type(active_wb).__name__ if active_wb else None
 
 if FreeCAD.GuiUp:
     for name in FreeCADGui.listWorkbenches():

--- a/src/freecad_mcp/bridge/xmlrpc.py
+++ b/src/freecad_mcp/bridge/xmlrpc.py
@@ -504,7 +504,7 @@ props = {{}}
 for prop in obj.PropertiesList:
     try:
         val = getattr(obj, prop)
-        if hasattr(val, '__class__') and val.__class__.__module__ != 'builtins':
+        if type(val).__module__ != 'builtins':
             val = str(val)
         props[prop] = val
     except Exception:
@@ -960,7 +960,7 @@ _result_ = {{
         code = """
 workbenches = []
 active_wb = FreeCADGui.activeWorkbench() if FreeCAD.GuiUp else None
-active_name = active_wb.__class__.__name__ if active_wb else None
+active_name = type(active_wb).__name__ if active_wb else None
 
 if FreeCAD.GuiUp:
     for name in FreeCADGui.listWorkbenches():


### PR DESCRIPTION
FreeCAD C++ Python bindings can return a `dict` from `obj.__class__` instead of the actual class type, causing `AttributeError: 'dict' object has no attribute '__name__'`. I specifically ran in to this on `inspect_object`.