### PR TITLE
fix: replace fragile class-name check in get_screenshot with duck typing

### DIFF
--- a/src/freecad_mcp/bridge/socket.py
+++ b/src/freecad_mcp/bridge/socket.py
@@ -709,12 +709,14 @@ if view is None:
 # across different FreeCAD versions, which crashes any name-based
 # check (see GitHub issue #82). Checking for the methods we actually
 # call below sidesteps that identity problem entirely.
-required_view_methods = (
+requiredViewMethods = (
     "fitAll", "viewIsometric", "viewFront", "viewRear",
     "viewTop", "viewBottom", "viewLeft", "viewRight", "saveImage",
 )
-if not all(hasattr(view, method) for method in required_view_methods):
-    raise ValueError("Cannot capture screenshot: active view does not support 3D view operations")
+if not all(hasattr(view, method) for method in requiredViewMethods):
+    raise ValueError(
+        "Cannot capture screenshot: active view does not support 3D view operations"
+    )
 
 # Set view angle
 view_type_str = {view_angle_str!r}

--- a/src/freecad_mcp/bridge/socket.py
+++ b/src/freecad_mcp/bridge/socket.py
@@ -702,10 +702,19 @@ view = FreeCADGui.ActiveDocument.ActiveView
 if view is None:
     raise ValueError("No active view")
 
-# Check view type
-view_type = view.__class__.__name__
-if view_type not in ["View3DInventor", "View3DInventorPy"]:
-    raise ValueError(f"Cannot capture screenshot from {{view_type}} view")
+# Check this view supports the 3D operations we need (rule out
+# TechDraw, Spreadsheet, etc.). Do not identify it by class name:
+# FreeCAD's View3DInventor proxy has had both __class__ and type()
+# intermittently return a dict of methods instead of the real type,
+# across different FreeCAD versions, which crashes any name-based
+# check (see GitHub issue #82). Checking for the methods we actually
+# call below sidesteps that identity problem entirely.
+required_view_methods = (
+    "fitAll", "viewIsometric", "viewFront", "viewRear",
+    "viewTop", "viewBottom", "viewLeft", "viewRight", "saveImage",
+)
+if not all(hasattr(view, method) for method in required_view_methods):
+    raise ValueError("Cannot capture screenshot: active view does not support 3D view operations")
 
 # Set view angle
 view_type_str = {view_angle_str!r}

--- a/src/freecad_mcp/bridge/xmlrpc.py
+++ b/src/freecad_mcp/bridge/xmlrpc.py
@@ -699,12 +699,19 @@ view = FreeCADGui.ActiveDocument.ActiveView
 if view is None:
     raise ValueError("No active view")
 
-# Check if this is a 3D view (not TechDraw, Spreadsheet, etc.)
-# Note: Use type() instead of __class__ because FreeCAD's View3DInventor
-# has a broken __class__ attribute that returns a dict of methods.
-view_type = type(view).__name__
-if view_type not in ["View3DInventor", "View3DInventorPy"]:
-    raise ValueError(f"Cannot capture screenshot from {{view_type}} view")
+# Check this view supports the 3D operations we need (rule out
+# TechDraw, Spreadsheet, etc.). Do not identify it by class name:
+# FreeCAD's View3DInventor proxy has had both __class__ and type()
+# intermittently return a dict of methods instead of the real type,
+# across different FreeCAD versions, which crashes any name-based
+# check (see GitHub issue #82). Checking for the methods we actually
+# call below sidesteps that identity problem entirely.
+required_view_methods = (
+    "fitAll", "viewIsometric", "viewFront", "viewRear",
+    "viewTop", "viewBottom", "viewLeft", "viewRight", "saveImage",
+)
+if not all(hasattr(view, method) for method in required_view_methods):
+    raise ValueError("Cannot capture screenshot: active view does not support 3D view operations")
 
 # Set view angle
 view_type_str = {view_angle_str!r}

--- a/src/freecad_mcp/bridge/xmlrpc.py
+++ b/src/freecad_mcp/bridge/xmlrpc.py
@@ -706,12 +706,14 @@ if view is None:
 # across different FreeCAD versions, which crashes any name-based
 # check (see GitHub issue #82). Checking for the methods we actually
 # call below sidesteps that identity problem entirely.
-required_view_methods = (
+requiredViewMethods = (
     "fitAll", "viewIsometric", "viewFront", "viewRear",
     "viewTop", "viewBottom", "viewLeft", "viewRight", "saveImage",
 )
-if not all(hasattr(view, method) for method in required_view_methods):
-    raise ValueError("Cannot capture screenshot: active view does not support 3D view operations")
+if not all(hasattr(view, method) for method in requiredViewMethods):
+    raise ValueError(
+        "Cannot capture screenshot: active view does not support 3D view operations"
+    )
 
 # Set view angle
 view_type_str = {view_angle_str!r}


### PR DESCRIPTION
Fixes #82.

## Summary

`get_screenshot`'s 3D-view guard identifies the active view by class name — `view.__class__.__name__` in `socket.py`, and `type(view).__name__` in `xmlrpc.py` (a prior, partial attempt at this same fix). Both are unreliable: FreeCAD's `View3DInventor` proxy has been observed to have **either** `__class__` **or** `type()` return a dict of methods instead of the real type, depending on FreeCAD version — which crashes the guard itself with `AttributeError: 'dict' object has no attribute '__name__'` before `saveImage()` is ever reached.

This replaces the name-based check with a duck-typed one: verify the view actually has the methods `get_screenshot` needs (`fitAll`, `viewIsometric`, `saveImage`, etc.) instead of asking what class it claims to be. This never touches the identity attributes (`__class__`/`type()`) that are the actual source of the crash.

## Why this approach

`bridge/embedded.py`'s `get_screenshot` already has no type check at all — it calls the view methods directly — and has no reported issues. This change brings `xmlrpc.py` and `socket.py` in line with that existing precedent in the same codebase, rather than inventing a third, different identity check that could break the same way on some future FreeCAD version.

## Verification

Live against FreeCAD 1.1.3 (macOS, xmlrpc mode):

| | result |
|---|---|
| `view.__class__` | returns a `dict` — reproduces the exact `AttributeError` from #82 |
| `type(view)` | works correctly on this build (`<class 'View3DInventorPy'>`) |
| patched duck-typed guard | passes; `saveImage()` produces a correct, non-empty PNG |

So on my machine specifically the crash comes from `__class__`, not `type()` — but per #82's own report, `type()` also breaks the same way on FreeCAD 1.1.1. The duck-typed check sidesteps both failure modes rather than needing to know which one applies to a given FreeCAD build.

- `uv run pytest tests/unit` — 420 passed (unchanged)
- `ruff check` / `ruff format --check` on both changed files — clean

## Test Plan

- [x] `uv run pytest tests/unit` — 420 passed
- [x] `ruff check src/freecad_mcp/bridge/xmlrpc.py src/freecad_mcp/bridge/socket.py` — clean
- [x] `ruff format --check` on both files — clean
- [x] Live FreeCAD 1.1.3, xmlrpc bridge: reproduced the original crash, confirmed the patched guard captures a correct screenshot
- [ ] `socket` bridge exercised live — patched identically (same duck-typed check) but I only have `xmlrpc` running to test against

## Notes

This doesn't overlap with #102 (open, unmerged) — that PR fixes a *different* screenshot bug (valid-but-empty captures from a render/framing race) and doesn't touch this guard clause at all; I checked its diff before starting this to avoid stepping on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot capture reliability across supported 3D views.
  * Unsupported view types now return a clear, consistent capture error instead of failing due to version-specific view names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->